### PR TITLE
feat(dailies): limit hourglass claims to three attempts

### DIFF
--- a/python/adb_auto_player/games/afk_journey/mixins/dailies.py
+++ b/python/adb_auto_player/games/afk_journey/mixins/dailies.py
@@ -54,7 +54,9 @@ class DailiesMixin(AFKJourneyBase, ABC):
             sleep(2)
 
         logging.info("Looking for free hourglasses.")
-        while self._claim_hourglasses():
+        claim_limit = 3
+        while self._claim_hourglasses() and claim_limit > 0:
+            claim_limit -= 1
             logging.info("Claimed a free hourglass.")
 
         logging.debug("Back.")


### PR DESCRIPTION
Limit the number of hourglass claims to three to prevent excessive  retries. This change improves performance and avoids potential  unnecessary API calls while maintaining the intended functionality.