### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -9,6 +9,9 @@ on:
       - 'python/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   python-tests:
     name: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/AdbAutoPlayer/AdbAutoPlayer/security/code-scanning/9](https://github.com/AdbAutoPlayer/AdbAutoPlayer/security/code-scanning/9)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function. Since the workflow only checks out the repository and runs Python tests, it only needs `contents: read` permissions. This change will ensure that the workflow does not have unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
