### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lychee-link-checking.yml
+++ b/.github/workflows/lychee-link-checking.yml
@@ -1,4 +1,6 @@
 name: mdBook validate links
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/AdbAutoPlayer/AdbAutoPlayer/security/code-scanning/7](https://github.com/AdbAutoPlayer/AdbAutoPlayer/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. Since the workflow only checks links and does not modify repository contents, the minimal required permission is `contents: read`. This ensures the workflow has the least privilege necessary to perform its tasks.

The `permissions` block will be added after the `name` field and before the `on` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
