### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,4 +1,6 @@
 name: Run - pre-commit
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/AdbAutoPlayer/AdbAutoPlayer/security/code-scanning/8](https://github.com/AdbAutoPlayer/AdbAutoPlayer/security/code-scanning/8)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function. Based on the tasks performed in the workflow, it appears that only `contents: read` is necessary, as the workflow does not modify repository contents or perform actions requiring write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
