### PR TITLE
Potential fix for code scanning alert no. 10: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -41,6 +41,15 @@ func UpdatePatch(assetUrl string) error {
 	for _, file := range zipReader.File {
 		outputPath := filepath.Join(".", file.Name)
 
+		// Validate the output path to prevent directory traversal
+		absOutputPath, err := filepath.Abs(outputPath)
+		if err != nil {
+			return fmt.Errorf("failed to resolve absolute path: %v", err)
+		}
+		if !strings.HasPrefix(absOutputPath, filepath.Clean(".")) {
+			return fmt.Errorf("invalid file path: %s", file.Name)
+		}
+
 		if file.FileInfo().IsDir() {
 			if err = os.MkdirAll(outputPath, 0755); err != nil {
 				return fmt.Errorf("failed to create directory: %v", err)


### PR DESCRIPTION
Potential fix for [https://github.com/AdbAutoPlayer/AdbAutoPlayer/security/code-scanning/10](https://github.com/AdbAutoPlayer/AdbAutoPlayer/security/code-scanning/10)

To fix the issue, we need to validate the `file.Name` field to ensure it does not contain directory traversal elements (`..`) or absolute paths. This can be achieved by checking the resolved `outputPath` against the intended extraction directory. If the resolved path is outside the target directory, the file should be skipped or an error should be raised.

Steps to implement the fix:
1. Use `filepath.Abs` to resolve the absolute path of `outputPath`.
2. Compare the resolved `outputPath` with the intended extraction directory (e.g., `.` in this case) using `filepath.HasPrefix` or equivalent logic.
3. Skip or reject files with invalid paths.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
