### PR TITLE
Potential fix for code scanning alert no. 30: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -7,6 +7,10 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  secrets: read
+
 jobs:
   go-tests:
     name: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/AdbAutoPlayer/AdbAutoPlayer/security/code-scanning/30](https://github.com/AdbAutoPlayer/AdbAutoPlayer/security/code-scanning/30)

To fix the issue, add an explicit `permissions` block to the workflow. This block should define the least privileges required for the workflow to function correctly. Based on the actions used in the workflow:
- `contents: read` is required for `actions/checkout@v4` to read repository contents.
- `contents: write` is not needed since the workflow does not modify repository contents.
- `secrets: read` is required to access the `CODECOV_TOKEN` secret.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as none of the jobs have unique permission requirements.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
