### PR TITLE
Titan reaver hotfix

### DIFF
--- a/python/adb_auto_player/games/afk_journey/mixins/titan_reaver_proxy_battle.py
+++ b/python/adb_auto_player/games/afk_journey/mixins/titan_reaver_proxy_battle.py
@@ -115,6 +115,7 @@ class TitanReaverProxyBattleMixin(AFKJourneyBase, ABC):
 
                 if self._execute_single_proxy_battle():
                     stats.battles_completed += 1
+                    stats.exception_count = 0
                     logging.info(f"Proxy Battle #{stats.battles_completed} completed")
                 else:
                     stats.exception_count += 1

--- a/python/adb_auto_player/games/afk_journey/mixins/titan_reaver_proxy_battle.py
+++ b/python/adb_auto_player/games/afk_journey/mixins/titan_reaver_proxy_battle.py
@@ -27,6 +27,9 @@ class TitanReaverProxyBattleConstants:
     RETRY_DELAY = 1  # Retry interval (seconds)
     NAVIGATION_DELAY = 1  # Navigation operation interval (seconds)
 
+    # Exception handling
+    MAX_EXCEPTION_COUNT = 10  # Maximum consecutive exceptions before reset
+
     # Coordinate constants
     CHAT_BUTTON_POINT = Point(1010, 1080)
 
@@ -119,7 +122,10 @@ class TitanReaverProxyBattleMixin(AFKJourneyBase, ABC):
                     logging.info(f"Proxy Battle #{stats.battles_completed} completed")
                 else:
                     stats.exception_count += 1
-                    if stats.exception_count >= 10:
+                    if (
+                        stats.exception_count
+                        >= TitanReaverProxyBattleConstants.MAX_EXCEPTION_COUNT
+                    ):
                         logging.error(
                             "Too many consecutive failures, resetting to default state"
                         )

--- a/python/adb_auto_player/games/afk_journey/mixins/titan_reaver_proxy_battle.py
+++ b/python/adb_auto_player/games/afk_journey/mixins/titan_reaver_proxy_battle.py
@@ -41,6 +41,7 @@ class TitanReaverProxyBattleStats:
 
     # battles_attempted: int = 0
     battles_completed: int = 0
+    exception_count: int = 0
 
     # Mapping from field name to display name
     _field_display_names: ClassVar[dict[str, str]] = {
@@ -116,6 +117,13 @@ class TitanReaverProxyBattleMixin(AFKJourneyBase, ABC):
                     stats.battles_completed += 1
                     logging.info(f"Proxy Battle #{stats.battles_completed} completed")
                 else:
+                    stats.exception_count += 1
+                    if stats.exception_count >= 10:
+                        logging.error(
+                            "Too many consecutive failures, resetting to default state"
+                        )
+                        self.navigate_to_default_state()
+                        stats.exception_count = 0
                     sleep(5)  # Wait longer after failure
 
         except KeyboardInterrupt as e:
@@ -227,7 +235,7 @@ class TitanReaverProxyBattleMixin(AFKJourneyBase, ABC):
 
     def _swipe_chat_down(self) -> None:
         """Swipe down the chat window."""
-        self.swipe_down(1000, 500, 1500)
+        self.swipe_down(1000, 800, 1500)
         sleep(TitanReaverProxyBattleConstants.NAVIGATION_DELAY)
 
     def _join_proxy_battle(self, banner_location: Point) -> bool:


### PR DESCRIPTION
- Add an exception limit to eliminate dead cycles. 
- Smaller swipe to handle the random "glitch" in the in-game chat.