### PR TITLE
12.9.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,9 @@
 # Changelog
 
-## [12.9.27] - 2026-08-06
+## [12.9.28] - 2026-08-11
 
-### Features
+### Bug Fixes
 
-- **Debug & Screenshots**:
-  - Added automatic screenshot capture on unknown popups, navigation failures, and template timeouts.
-  - Added debug screenshot saving functionality in screenshot mixin for offline troubleshooting.
-
-### Refactoring
-
-- Changed negative `Point` coordinate clamping log level from warning to debug.
+- **Device Streaming**: Fixed emulator detection false-positives on Google Tensor Pixel phones (6/7/8/9 series), whose Samsung modem firmware string was misread as an emulator marker, silently blocking Device Streaming on macOS and degrading capture on other platforms.
+- **Profiles**: Fixed deleting a profile leaving its settings folder behind instead of cleaning it up, which could cause a later profile to silently read/write another profile's settings.
+- **Profiles**: Fixed a cache-clearing bug where saving settings for profile 0 could clear cached state for other profiles too.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adb-auto-player"
-version = "12.9.27"
+version = "12.9.28"
 dependencies = [
  "chrono",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["src-tauri"]
 resolver = "2"
 
 [workspace.package]
-version = "12.9.27"
+version = "12.9.28"
 edition = "2021"
 
 

--- a/package.json
+++ b/package.json
@@ -53,5 +53,5 @@
     "tauri": "tauri"
   },
   "type": "module",
-  "version": "12.9.27"
+  "version": "12.9.28"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "workspace"
-version = "12.9.27"
+version = "12.9.28"
 requires-python = ">=3.11"
 dependencies = [
     "pytest-cov>=7.1.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adb-auto-player"
-version = "12.9.27"
+version = "12.9.28"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/pyproject.toml
+++ b/src-tauri/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "adb-auto-player"
-version = "12.9.27"
+version = "12.9.28"
 description = ""
 readme = "README.md"
 authors = [

--- a/src-tauri/src-python/adb_auto_player/device/adb/adb_controller.py
+++ b/src-tauri/src-python/adb_auto_player/device/adb/adb_controller.py
@@ -11,6 +11,21 @@ from adb_auto_player.tauri_context import profile_aware_cache
 
 from .adb_device import AdbDeviceWrapper
 
+# getprop keys/substrings that only ever appear under virtualization.
+# Real hardware is never misdetected as an emulator by these; the risk is the
+# opposite direction (a new/obfuscated emulator not being detected).
+_EMULATOR_PROP_MARKERS = (
+    "ro.kernel.qemu",
+    "ro.boot.qemu",
+    "ro.hardware.virtual_device",
+    "ro.bst.",  # BlueStacks
+    "nemu",  # MuMu / Nemu
+    "microvirt",  # MuMu / LDPlayer lineage
+    "goldfish",  # AOSP emulator (ARM)
+    "ranchu",  # AOSP emulator (x86)
+    "vbox",  # Genymotion / VirtualBox-backed
+)
+
 
 class AdbController:
     """Functions to control an ADB device."""
@@ -311,10 +326,19 @@ class AdbController:
     @profile_aware_cache(maxsize=1)
     def is_controlling_emulator(self):
         """Whether the controlled device is an emulator or not."""
-        result = str(self.d.shell('getprop | grep "Build"'))
-        if "Build" in result:
-            return True
-        logging.debug('getprop does not contain "Build" assuming Phone')
+        props = str(self.d.shell("getprop"))
+        for marker in _EMULATOR_PROP_MARKERS:
+            if marker in props:
+                logging.debug(f"getprop contains {marker!r} assuming Emulator")
+                return True
+        if "Build" in props:
+            logging.debug(
+                "getprop contains 'Build' but no known emulator marker; "
+                "assuming Phone. If this is actually an emulator, please "
+                "report it so its marker can be added."
+            )
+        else:
+            logging.debug("no emulator markers in getprop assuming Phone")
         return False
 
     def get_input_device(self, name: str) -> str | None:

--- a/src-tauri/src-python/adb_auto_player/tauri_context/cache.py
+++ b/src-tauri/src-python/adb_auto_player/tauri_context/cache.py
@@ -50,7 +50,7 @@ def profile_aware_cache(maxsize: int | None = None):
             profile_index=int   → clear only that profile
             """
             with lock:
-                if not profile_index:
+                if profile_index is None:
                     caches.clear()
                     return
 

--- a/src-tauri/src-python/tests/device/adb/test_adb_controller.py
+++ b/src-tauri/src-python/tests/device/adb/test_adb_controller.py
@@ -115,3 +115,43 @@ class TestResolveDisplayIds:
         controller.tap(Point(460, 1830))
 
         mock_d.tap.assert_called_once_with("460", "1830", display_id=None)
+
+
+class TestIsControllingEmulator:
+    """Regression tests for `AdbController.is_controlling_emulator`.
+
+    The old heuristic matched the unanchored substring "Build" anywhere in
+    the full `getprop` dump. On Tensor Pixels (6/7/8/9 series), the Samsung
+    vendor RIL firmware string contains "Build <date>", which is unrelated
+    to the OS build and caused real phones to be misdetected as emulators.
+    """
+
+    def test_tensor_pixel_ril_string_is_not_an_emulator(self):
+        controller, _ = _make_controller(
+            [
+                "[gsm.version.ril-impl]: [Samsung S.LSI Vendor RIL 5400 V2.3 "
+                "Build 2026-04-30 04:48:08]"
+            ]
+        )
+
+        assert controller.is_controlling_emulator is False
+
+    def test_qemu_marker_is_an_emulator(self):
+        controller, _ = _make_controller(["[ro.kernel.qemu]: [1]"])
+
+        assert controller.is_controlling_emulator is True
+
+    def test_bluestacks_marker_is_an_emulator(self):
+        controller, _ = _make_controller(["[ro.bst.build.type]: [release]"])
+
+        assert controller.is_controlling_emulator is True
+
+    def test_mumu_marker_is_an_emulator(self):
+        controller, _ = _make_controller(["[ro.product.brand]: [nemu]"])
+
+        assert controller.is_controlling_emulator is True
+
+    def test_no_props_is_not_an_emulator(self):
+        controller, _ = _make_controller(["[ro.product.brand]: [google]"])
+
+        assert controller.is_controlling_emulator is False

--- a/src-tauri/src-python/tests/tauri_context/test_cache.py
+++ b/src-tauri/src-python/tests/tauri_context/test_cache.py
@@ -1,0 +1,54 @@
+"""Tests for `profile_aware_cache`.
+
+Regression test for: `cache_clear(profile_index)` used `if not profile_index`,
+which treats `profile_index=0` the same as `profile_index=None` (falsy-zero
+bug). Saving settings for profile 0 was wiping every other profile's cache
+instead of only profile 0's.
+"""
+
+from adb_auto_player.tauri_context.cache import profile_aware_cache
+from adb_auto_player.tauri_context.context import TauriContext
+
+
+def _set_profile_and_call(func, profile_index: int | None):
+    TauriContext.set_profile_index(profile_index)
+    return func()
+
+
+class TestProfileAwareCacheClear:
+    """Tests for `profile_aware_cache(...).cache_clear`."""
+
+    def test_clearing_profile_zero_does_not_clear_other_profiles(self):
+        calls: list[int | None] = []
+
+        @profile_aware_cache(maxsize=1)
+        def func():
+            calls.append(1)
+            return len(calls)
+
+        _set_profile_and_call(func, 0)
+        _set_profile_and_call(func, 1)
+        assert calls == [1, 1]
+
+        func.cache_clear(0)
+
+        # Profile 0 was cleared: calling it again recomputes.
+        assert _set_profile_and_call(func, 0) == 3
+        # Profile 1's cached value must be untouched.
+        assert _set_profile_and_call(func, 1) == 2
+
+    def test_clearing_with_none_clears_all_profiles(self):
+        calls: list[int | None] = []
+
+        @profile_aware_cache(maxsize=1)
+        def func():
+            calls.append(1)
+            return len(calls)
+
+        _set_profile_and_call(func, 0)
+        _set_profile_and_call(func, 1)
+
+        func.cache_clear(None)
+
+        assert _set_profile_and_call(func, 0) == 3
+        assert _set_profile_and_call(func, 1) == 4

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -50,3 +50,39 @@ pub fn save_settings(
 
     Ok(())
 }
+
+/// Keep per-profile settings folders (`{config_dir}/{profile_index}/`) in sync
+/// with the profile array after a profile is deleted from the frontend.
+///
+/// Profile folders are named after their array position, not a stable ID, so
+/// deleting an entry shifts every later profile's index without this — each
+/// later profile would then read/write the settings folder that used to
+/// belong to whichever profile occupied that slot before.
+#[tauri::command]
+pub fn delete_profile_settings(
+    app_handle: AppHandle,
+    deleted_index: u8,
+    profile_count_before: u8,
+) -> Result<(), CommandError> {
+    let config_dir = app_handle
+        .path()
+        .app_config_dir()
+        .map_err(|_| CommandError::ConfigDirNotFound)?;
+
+    let profile_dir = |index: u8| config_dir.join(index.to_string());
+
+    let deleted_dir = profile_dir(deleted_index);
+    if deleted_dir.exists() {
+        fs::remove_dir_all(&deleted_dir)?;
+    }
+
+    for index in (deleted_index + 1)..profile_count_before {
+        let from = profile_dir(index);
+        let to = profile_dir(index - 1);
+        if from.exists() {
+            fs::rename(&from, &to)?;
+        }
+    }
+
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -58,6 +58,7 @@ pub mod ext_mod {
                         save_settings,
                         get_app_settings_form,
                         save_app_settings,
+                        delete_profile_settings,
                     ])
                     .setup(|app| {
                         app.manage(std::sync::Mutex::new(AppSettings::default()));

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -418,6 +418,8 @@ pub fn get_app_settings_form(
 ) -> Result<AppSettingsResponse, CommandError> {
     let settings = AppSettings::load_from_file(get_app_settings_path(&app_handle));
 
+    warn_on_orphaned_profile_dirs(&app_handle, &settings);
+
     // Update state
     {
         let mut s = state.lock().unwrap();
@@ -429,6 +431,42 @@ pub fn get_app_settings_form(
         schema: APP_SETTINGS_SCHEMA.to_string(),
         file_name: "App.toml".to_string(),
     })
+}
+
+/// Warn if there are more numbered profile-settings folders on disk than
+/// configured profiles. This can't happen from normal use, but was the
+/// observable symptom of a bug where deleting a profile left its settings
+/// folder behind instead of cleaning it up, causing later profiles to read
+/// the wrong folder. Purely informational: which folder actually belongs to
+/// which profile can't be reconstructed, so this only surfaces the mismatch
+/// rather than trying to fix it automatically.
+fn warn_on_orphaned_profile_dirs(app_handle: &tauri::AppHandle, settings: &AppSettings) {
+    let Ok(config_dir) = app_handle.path().app_config_dir() else {
+        return;
+    };
+
+    let dir_count = fs::read_dir(&config_dir)
+        .map(|entries| {
+            entries
+                .flatten()
+                .filter(|entry| {
+                    entry.path().is_dir()
+                        && entry.file_name().to_string_lossy().parse::<u32>().is_ok()
+                })
+                .count()
+        })
+        .unwrap_or(0);
+    let profile_count = settings.profiles.profiles.len();
+
+    if dir_count > profile_count {
+        let message = format!(
+            "Found {dir_count} profile settings folder(s) but only {profile_count} \
+             profile(s) configured in {}. A profile may be reading another \
+             profile's leftover settings folder from a previous deletion.",
+            config_dir.display()
+        );
+        let _ = app_handle.emit("log-message", LogMessage::new(LogLevel::WARNING, message));
+    }
 }
 
 #[tauri::command]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -47,5 +47,5 @@
     }
   },
   "productName": "AdbAutoPlayer",
-  "version": "12.9.27"
+  "version": "12.9.28"
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -290,6 +290,14 @@
     }
 
     try {
+      // Profile settings folders are named after array position, not a
+      // stable ID — shift/remove them on disk before the array itself
+      // shrinks, or later profiles would silently read the wrong folder.
+      await invoke("delete_profile_settings", {
+        deletedIndex: index,
+        profileCountBefore: currentProfiles.length,
+      });
+
       const newSettings = {
         ...settings.settings,
         profiles: {

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ members = [
 
 [[package]]
 name = "adb-auto-player"
-version = "12.9.27"
+version = "12.9.28"
 source = { editable = "src-tauri" }
 dependencies = [
     { name = "adbutils" },
@@ -1205,7 +1205,7 @@ wheels = [
 
 [[package]]
 name = "workspace"
-version = "12.9.27"
+version = "12.9.28"
 source = { virtual = "." }
 dependencies = [
     { name = "onnxruntime" },


### PR DESCRIPTION
# Changelog

## [12.9.28] - 2026-08-11

### Bug Fixes

- **Device Streaming**: Fixed emulator detection false-positives on Google Tensor Pixel phones (6/7/8/9 series), whose Samsung modem firmware string was misread as an emulator marker, silently blocking Device Streaming on macOS and degrading capture on other platforms.
- **Profiles**: Fixed deleting a profile leaving its settings folder behind instead of cleaning it up, which could cause a later profile to silently read/write another profile's settings.
- **Profiles**: Fixed a cache-clearing bug where saving settings for profile 0 could clear cached state for other profiles too.
