### PR TITLE
12.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,8 @@
 # Changelog
 
-## [12.9.29] - 2026-08-13
-
-### Bug Fixes
-
-- **Device Streaming**: Fixed emulator detection on HyperOS (POCO X5 Pro) where
-  `ro.kernel.qemu` is present but set to `0`, incorrectly identifying physical
-  devices as emulators.
-- **CLI**: Fixed logging format in CLI exception handling to properly pass the
-  exception object for traceback logging.
-- **AFK Journey**: Fixed exception logging format in formation copying.
+## [12.10.0] - 2026-08-14
 
 ### Features
 
-- **Game Engine**: Added `diagnostic_recheck` parameter to
-  `wait_for_template` / `wait_for_any_template` to perform an extra check after
-  timeout and suggest a proper timeout value, helping debug slow navigation
-  steps.
-- **AFK Journey**: Enabled diagnostic recheck for the formation selection
-  screen and added debug screenshot capture on failure.
+- **Watchdog**: Added `max_consecutive_restarts` advanced setting (defaulting to 5) to prevent infinite restart loops when a task fails repeatedly within a short timeframe.
+- **Diagnostics**: Enabled `diagnostic_recheck` for various AFK Journey navigation screens and added automatic debug screenshot capture on navigation timeout failures.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adb-auto-player"
-version = "12.9.29"
+version = "12.10.0"
 dependencies = [
  "chrono",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["src-tauri"]
 resolver = "2"
 
 [workspace.package]
-version = "12.9.29"
+version = "12.10.0"
 edition = "2021"
 
 

--- a/package.json
+++ b/package.json
@@ -53,5 +53,5 @@
     "tauri": "tauri"
   },
   "type": "module",
-  "version": "12.9.29"
+  "version": "12.10.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "workspace"
-version = "12.9.29"
+version = "12.10.0"
 requires-python = ">=3.11"
 dependencies = [
     "pytest-cov>=7.1.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adb-auto-player"
-version = "12.9.29"
+version = "12.10.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/pyproject.toml
+++ b/src-tauri/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "adb-auto-player"
-version = "12.9.29"
+version = "12.10.0"
 description = ""
 readme = "README.md"
 authors = [

--- a/src-tauri/src-python/adb_auto_player/device/adb/adb_controller.py
+++ b/src-tauri/src-python/adb_auto_player/device/adb/adb_controller.py
@@ -164,6 +164,20 @@ class AdbController:
         """
         self._ensure_display_ids_resolved(package_name_prefixes)
 
+    def reset_display_targeting(self) -> None:
+        """Drop cached display ids so the next screenshot/stream re-resolves them.
+
+        On multi-display emulators (e.g. MuMuPlayer's Android 15 image) the
+        game's virtual display is torn down and recreated with a new id every
+        time the app is force-stopped and relaunched. Without this, a
+        mid-task `restart_game()` leaves `screenshot()`/`DeviceStream`
+        targeting a display id that no longer exists, causing screenshots to
+        fail indefinitely on every retry after the restart.
+        """
+        self._screenshot_display_id = None
+        self._input_display_id = None
+        self._display_ids_resolved = False
+
     def _ensure_display_ids_resolved(self, package_name_prefixes: list[str]) -> None:
         """Resolve and cache the game's display ids, once, if not already done."""
         if self._display_ids_resolved:

--- a/src-tauri/src-python/adb_auto_player/game/_lifecycle_mixin.py
+++ b/src-tauri/src-python/adb_auto_player/game/_lifecycle_mixin.py
@@ -65,6 +65,10 @@ class _LifecycleMixin(_GameBase):
         """Force-stop then relaunch the game."""
         self.force_stop_game()
         self.start_game()
+        # A relaunch can get a new virtual display (id) on multi-display
+        # emulators, so cached display targeting must be re-resolved.
+        self.device.reset_display_targeting()
+        self.device.resolve_display_targeting(self.package_name_prefixes)
 
     def assert_frame_and_input_delay_below_threshold(
         self,

--- a/src-tauri/src-python/adb_auto_player/games/afk_journey/base.py
+++ b/src-tauri/src-python/adb_auto_player/games/afk_journey/base.py
@@ -211,9 +211,11 @@ class AFKJourneyBase(
                 timeout=timeout,
                 crop_regions=CropRegions(top=0.5),
                 threshold=ConfidenceValue("80%"),
+                diagnostic_recheck=raise_on_timeout,
             )
         except GameTimeoutError as error:
             if raise_on_timeout:
+                self.capture_debug_screenshot("battle_screen_not_found")
                 raise error
             return None
 

--- a/src-tauri/src-python/adb_auto_player/games/afk_journey/navigation.py
+++ b/src-tauri/src-python/adb_auto_player/games/afk_journey/navigation.py
@@ -264,11 +264,13 @@ class Navigation(PopupMessageHandler, ABC):
                         "resonating_hall/equipment.png",
                     ],
                     timeout=self.navigation_timeout,
+                    diagnostic_recheck=True,
                 )
                 logging.debug("Successfully entered Resonating Hall.")
                 break
             except AutoPlayerError as e:
                 logging.warning(e)
+                self.capture_debug_screenshot("resonating_hall_not_found")
                 last_error = e
         self.sleep_action()
         return
@@ -294,11 +296,16 @@ class Navigation(PopupMessageHandler, ABC):
             "battle_modes/afk_stage.png", ConfidenceValue("75%")
         )
 
-        self.wait_for_template(
-            template="navigation/resonating_hall_label.png",
-            crop_regions=CropRegions(left=0.3, right=0.3, top=0.9),
-            timeout=self.navigation_timeout,
-        )
+        try:
+            self.wait_for_template(
+                template="navigation/resonating_hall_label.png",
+                crop_regions=CropRegions(left=0.3, right=0.3, top=0.9),
+                timeout=self.navigation_timeout,
+                diagnostic_recheck=True,
+            )
+        except GameTimeoutError as e:
+            self.capture_debug_screenshot("afk_stages_screen_not_found")
+            raise e
         self.tap(Point(x=550, y=1080))  # click rewards popup
         self.sleep_action()
 
@@ -313,6 +320,7 @@ class Navigation(PopupMessageHandler, ABC):
             ],
             threshold=ConfidenceValue("75%"),
             timeout=self.template_timeout,
+            diagnostic_recheck=True,
         )
 
         if result.template != "popup/quick_purchase.png":
@@ -329,6 +337,7 @@ class Navigation(PopupMessageHandler, ABC):
             ],
             threshold=ConfidenceValue("75%"),
             timeout=self.template_timeout,
+            diagnostic_recheck=True,
         )
 
     def navigate_to_battle_modes_screen(self) -> None:
@@ -342,6 +351,7 @@ class Navigation(PopupMessageHandler, ABC):
             except GameTimeoutError as e:
                 attempt += 1
                 if attempt >= max_attempts:
+                    self.capture_debug_screenshot("battle_modes_screen_not_found")
                     raise e
                 else:
                     continue
@@ -374,11 +384,16 @@ class Navigation(PopupMessageHandler, ABC):
         self.tap(self.CENTER_POINT)
         self.tap(self.CENTER_POINT)
 
-        self.wait_for_template(
-            template="duras_trials/socketed_charms_overview.png",
-            crop_regions=CropRegions(left=0.7, bottom=0.8),
-            timeout=self.template_timeout,
-        )
+        try:
+            self.wait_for_template(
+                template="duras_trials/socketed_charms_overview.png",
+                crop_regions=CropRegions(left=0.7, bottom=0.8),
+                timeout=self.template_timeout,
+                diagnostic_recheck=True,
+            )
+        except GameTimeoutError as e:
+            self.capture_debug_screenshot("duras_trials_screen_not_found")
+            raise e
         self.sleep_action()
         return
 
@@ -389,11 +404,16 @@ class Navigation(PopupMessageHandler, ABC):
             self.swipe_up(sy=1350, ey=500)
             self.sleep_navigation()
 
-        return self.wait_for_template(
-            template=template,
-            timeout_message=timeout_message,
-            timeout=self.template_timeout,
-        )
+        try:
+            return self.wait_for_template(
+                template=template,
+                diagnostic_recheck=True,
+                timeout_message=timeout_message,
+                timeout=self.template_timeout,
+            )
+        except GameTimeoutError as e:
+            self.capture_debug_screenshot("battle_mode_entry_not_found")
+            raise e
 
     def navigate_to_legend_trials_select_tower(self) -> None:
         """Navigate to Legend Trials select tower screen."""
@@ -406,18 +426,23 @@ class Navigation(PopupMessageHandler, ABC):
         )
 
         self._tap_till_template_disappears(result.template)
-        self.wait_for_any_template(
-            templates=[
-                "legend_trials/s_header.png",
-                "legend_trials/banner_lightbearer.png",
-                "legend_trials/banner_wilder.png",
-                "legend_trials/banner_graveborn.png",
-                "legend_trials/banner_mauler.png",
-            ],
-            crop_regions=CropRegions(left=0.1, right=0.1, top=0.1, bottom=0.1),
-            timeout_message="Could not find Legend Trial Header",
-            timeout=self.template_timeout,
-        )
+        try:
+            self.wait_for_any_template(
+                templates=[
+                    "legend_trials/s_header.png",
+                    "legend_trials/banner_lightbearer.png",
+                    "legend_trials/banner_wilder.png",
+                    "legend_trials/banner_graveborn.png",
+                    "legend_trials/banner_mauler.png",
+                ],
+                crop_regions=CropRegions(left=0.1, right=0.1, top=0.1, bottom=0.1),
+                timeout_message="Could not find Legend Trial Header",
+                timeout=self.template_timeout,
+                diagnostic_recheck=True,
+            )
+        except GameTimeoutError as e:
+            self.capture_debug_screenshot("legend_trials_screen_not_found")
+            raise e
         self.sleep_action()
 
     def navigate_to_arcane_labyrinth(self) -> None:
@@ -453,17 +478,22 @@ class Navigation(PopupMessageHandler, ABC):
 
         self._tap_till_template_disappears(result.template)
         self.sleep_navigation()
-        _ = self.wait_for_any_template(
-            templates=[
-                "arcane_labyrinth/select_a_crest.png",
-                "arcane_labyrinth/confirm.png",
-                "arcane_labyrinth/quit.png",
-                "arcane_labyrinth/enter.png",
-                "arcane_labyrinth/heroes_icon.png",
-            ],
-            threshold=ConfidenceValue("70%"),
-            delay=1,
-        )
+        try:
+            _ = self.wait_for_any_template(
+                templates=[
+                    "arcane_labyrinth/select_a_crest.png",
+                    "arcane_labyrinth/confirm.png",
+                    "arcane_labyrinth/quit.png",
+                    "arcane_labyrinth/enter.png",
+                    "arcane_labyrinth/heroes_icon.png",
+                ],
+                threshold=ConfidenceValue("70%"),
+                delay=1,
+                diagnostic_recheck=True,
+            )
+        except GameTimeoutError as e:
+            self.capture_debug_screenshot("arcane_labyrinth_entry_not_found")
+            raise e
         return
 
     def navigate_to_world_chat(self) -> None:
@@ -480,11 +510,16 @@ class Navigation(PopupMessageHandler, ABC):
             return
 
         self.navigate_to_world_chat()
-        world_chat_label = self.wait_for_template(
-            "chat/label_world_chat.png",
-            crop_regions=CropRegions(bottom="50%", right="50%", left="10%"),
-            timeout=5,
-        )
+        try:
+            world_chat_label = self.wait_for_template(
+                "chat/label_world_chat.png",
+                crop_regions=CropRegions(bottom="50%", right="50%", left="10%"),
+                timeout=5,
+                diagnostic_recheck=True,
+            )
+        except GameTimeoutError as e:
+            self.capture_debug_screenshot("world_chat_label_not_found")
+            raise e
         self.tap(
             world_chat_label.box.top_left + Offset(-70, 550),
             log_message="Opening Team-Up chat",

--- a/src-tauri/src-python/adb_auto_player/models/pydantic/app_settings.py
+++ b/src-tauri/src-python/adb_auto_player/models/pydantic/app_settings.py
@@ -134,6 +134,16 @@ class AdvancedSettings(BaseModel):
         title="Watchdog Restart Delay (Seconds)",
         description="Wait time before restarting the task if the game is closed.",
     )
+    max_consecutive_restarts: int = Field(
+        default=5,
+        ge=1,
+        le=20,
+        title="Watchdogs: Max Consecutive Restarts",
+        description=(
+            "Give up instead of restarting again after this many restarts in a "
+            "row fail to keep the task running for at least 5 minutes."
+        ),
+    )
 
 
 class AppSettings(TomlSettings):

--- a/src-tauri/src-python/adb_auto_player/util/execute.py
+++ b/src-tauri/src-python/adb_auto_player/util/execute.py
@@ -29,6 +29,12 @@ from adb_auto_player.models.commands import Command
 
 from .summary_generator import SummaryGenerator
 
+_DEFAULT_MAX_CONSECUTIVE_RESTARTS = 5
+# A restart attempt that keeps the task running this long before failing
+# again is treated as "resolved" — the consecutive-failure streak resets
+# instead of counting toward the give-up cap.
+_CONSECUTIVE_FAILURE_RESET_SECONDS = 5 * 60
+
 
 class Execute:
     """Util class for executing commands, callables, etc."""
@@ -68,6 +74,8 @@ class Execute:
 
         timeout_mins = 0
         timeout_enabled = False
+        watchdog_restart_delay = 40
+        max_consecutive_restarts = _DEFAULT_MAX_CONSECUTIVE_RESTARTS
         try:
             # App.toml is located in the root config dir, not the profile dir
             app_config_dir = SettingsLoader.get_app_config_dir().parent
@@ -80,12 +88,49 @@ class Execute:
                     timeout_mins = advanced.get("restart_stuck_task_after_mins", 60)
                     if timeout_enabled:
                         timeout_mins = max(3, timeout_mins)
-                    watchdog_restart_delay = advanced.get("watchdog_restart_delay", 40)
+                    watchdog_restart_delay = advanced.get(
+                        "watchdog_restart_delay", watchdog_restart_delay
+                    )
+                    max_consecutive_restarts = advanced.get(
+                        "max_consecutive_restarts", max_consecutive_restarts
+                    )
         except Exception:
-            watchdog_restart_delay = 40
+            pass
 
         # --- Watchdog Logic (Activity Based) ---
         last_activity_time = time.monotonic()
+        consecutive_restart_failures = 0
+        attempt_start_time = time.monotonic()
+
+        def register_restart_attempt() -> bool:
+            """Count a restart attempt and decide whether to keep retrying.
+
+            Resets the consecutive-failure streak if the previous attempt
+            kept the task running for at least
+            `_CONSECUTIVE_FAILURE_RESET_SECONDS` before failing again, so an
+            isolated failure after a long healthy run isn't penalized by an
+            earlier, unrelated run of failures.
+
+            Returns:
+                bool: True if under the cap and the caller should attempt
+                    `restart_game()`. False if the consecutive-restart cap
+                    has been reached and the task should give up.
+            """
+            nonlocal consecutive_restart_failures, attempt_start_time
+            if (
+                time.monotonic() - attempt_start_time
+                >= _CONSECUTIVE_FAILURE_RESET_SECONDS
+            ):
+                consecutive_restart_failures = 0
+            consecutive_restart_failures += 1
+            attempt_start_time = time.monotonic()
+            if consecutive_restart_failures > max_consecutive_restarts:
+                logging.error(
+                    f"Giving up after {consecutive_restart_failures} consecutive "
+                    "restarts failed to keep the task running."
+                )
+                return False
+            return True
 
         class ActivityTrackerHandler(logging.Handler):
             def emit(self, record):
@@ -208,7 +253,11 @@ class Execute:
                             "Task timeout triggered, restarting game and "
                             "retrying task..."
                         )
-                        if instance is not None and hasattr(instance, "restart_game"):
+                        if (
+                            instance is not None
+                            and hasattr(instance, "restart_game")
+                            and register_restart_attempt()
+                        ):
                             try:
                                 cast(Any, instance).restart_game()
                                 timeout_triggered = False
@@ -237,7 +286,11 @@ class Execute:
                             f"Task failed with error: {e}. "
                             "Restarting game and retrying..."
                         )
-                        if instance is not None and hasattr(instance, "restart_game"):
+                        if (
+                            instance is not None
+                            and hasattr(instance, "restart_game")
+                            and register_restart_attempt()
+                        ):
                             try:
                                 cast(Any, instance).restart_game()
                                 logging.info(

--- a/src-tauri/src-python/tests/utils/test_execute_restart.py
+++ b/src-tauri/src-python/tests/utils/test_execute_restart.py
@@ -132,6 +132,54 @@ class TestExecuteRestart(unittest.TestCase):
             self.assertIsInstance(result, GenericAdbUnrecoverableError)
             mock_instance.restart_game.assert_not_called()
 
+    def test_gives_up_after_max_consecutive_restarts(self) -> None:
+        """Test that the task stops restarting after hitting the cap.
+
+        Regression test for an infinite restart loop: a task that keeps
+        failing immediately after every restart (e.g. because the game's
+        display id changed and screenshots can never succeed again) used to
+        retry forever. `restart_game()` itself succeeding each time — it's
+        the *task* that keeps failing right after — so the cap must be
+        enforced independently of whether `restart_game()` raises.
+        """
+        mock_action = MagicMock(side_effect=Exception("Normal error"))
+        cmd = Command(name="ErrorCommand", action=mock_action)
+        commands = {"category": [cmd]}
+
+        mock_instance = MagicMock()
+        mock_instance.restart_game = MagicMock()
+
+        app_settings = {
+            "advanced": {
+                "restart_stuck_task": True,
+                "restart_stuck_task_after_mins": 5,
+                "max_consecutive_restarts": 3,
+            }
+        }
+
+        with (
+            patch("time.sleep", return_value=None),
+            patch(
+                "adb_auto_player.util.execute.tomllib.load", return_value=app_settings
+            ),
+            patch("builtins.open", mock_open()),
+            patch(
+                "adb_auto_player.file_loader.SettingsLoader.get_app_config_dir",
+                return_value=Path("dummy"),
+            ),
+            patch("pathlib.Path.exists", return_value=True),
+        ):
+            result = Execute.find_command_and_execute(
+                "errorcommand", commands, instance=mock_instance
+            )
+
+            self.assertIsInstance(result, Exception)
+            # The action is called once per attempt: 3 allowed restarts means
+            # 4 total attempts (the initial one plus 3 retries) before giving
+            # up instead of retrying forever.
+            self.assertEqual(mock_action.call_count, 4)
+            self.assertEqual(mock_instance.restart_game.call_count, 3)
+
     def test_restart_on_exception_failure(self) -> None:
         """Test that the task returns the original error when restart_game fails."""
         mock_action = MagicMock(side_effect=Exception("Normal error"))

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -65,6 +65,14 @@ const APP_SETTINGS_SCHEMA: &str = r##"
             "minimum": 10,
             "maximum": 300,
             "formType": "slider"
+          },
+          "max_consecutive_restarts": {
+            "default": 5,
+            "title": "Watchdogs: Max Consecutive Restarts",
+            "description": "Give up instead of restarting again after this many restarts in a row fail to keep the task running for at least 5 minutes.",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 20
           }
         },
         "title": "AdvancedSettings",
@@ -295,6 +303,8 @@ pub struct AdvancedSettings {
     pub template_timeout: f32,
     #[serde(default = "default_watchdog_restart_delay")]
     pub watchdog_restart_delay: u32,
+    #[serde(default = "default_max_consecutive_restarts")]
+    pub max_consecutive_restarts: u32,
 }
 
 impl Default for AdvancedSettings {
@@ -307,6 +317,7 @@ impl Default for AdvancedSettings {
             navigation_delay: default_navigation_delay(),
             template_timeout: default_template_timeout(),
             watchdog_restart_delay: default_watchdog_restart_delay(),
+            max_consecutive_restarts: default_max_consecutive_restarts(),
         }
     }
 }
@@ -325,6 +336,10 @@ fn default_template_timeout() -> f32 {
 
 fn default_watchdog_restart_delay() -> u32 {
     40
+}
+
+fn default_max_consecutive_restarts() -> u32 {
+    5
 }
 
 fn default_restart_mins() -> u32 {
@@ -388,6 +403,9 @@ impl AppSettings {
         }
         if self.advanced.restart_stuck_task_after_mins < 3 {
             self.advanced.restart_stuck_task_after_mins = default_restart_mins();
+        }
+        if self.advanced.max_consecutive_restarts < 1 {
+            self.advanced.max_consecutive_restarts = default_max_consecutive_restarts();
         }
     }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -47,5 +47,5 @@
     }
   },
   "productName": "AdbAutoPlayer",
-  "version": "12.9.29"
+  "version": "12.10.0"
 }

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ members = [
 
 [[package]]
 name = "adb-auto-player"
-version = "12.9.29"
+version = "12.10.0"
 source = { editable = "src-tauri" }
 dependencies = [
     { name = "adbutils" },
@@ -1205,7 +1205,7 @@ wheels = [
 
 [[package]]
 name = "workspace"
-version = "12.9.29"
+version = "12.10.0"
 source = { virtual = "." }
 dependencies = [
     { name = "onnxruntime" },


### PR DESCRIPTION
# Changelog

## [12.10.0] - 2026-08-14

### Features

- **Watchdog**: Added `max_consecutive_restarts` advanced setting (defaulting to 5) to prevent infinite restart loops when a task fails repeatedly within a short timeframe.
- **Diagnostics**: Enabled `diagnostic_recheck` for various AFK Journey navigation screens and added automatic debug screenshot capture on navigation timeout failures.
