### PR TITLE
fix: align tauri plugin crate/npm versions to unblock publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4116,9 +4116,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-notification"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
+checksum = "ad2fd40946aef810c4be9fd33a2d1b9b397cb79042b2d21c81a0a8f204354fd1"
 dependencies = [
  "log",
  "notify-rust",
@@ -4196,9 +4196,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-updater"
-version = "2.10.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+checksum = "b28d8cabdeb0564f03ae261963de4bc3d98321cd3d213e76a81b7d344e5df606"
 dependencies = [
  "base64 0.22.1",
  "dirs",


### PR DESCRIPTION
## Summary
- The v12.12.1 publish workflow failed on both macOS and Windows builds with `Error [tauri_cli_node] Found version mismatched Tauri packages`.
- `Cargo.lock` had `tauri-plugin-updater` pinned to `2.10.1` and `tauri-plugin-notification` to `2.3.3`, while the npm packages (`@tauri-apps/plugin-updater` `2.11.0`, `@tauri-apps/plugin-notification` `2.4.0`) were already bumped by Dependabot. `tauri-cli` now hard-fails the build when a plugin's Rust crate and npm package are on different minor versions — this check only runs during a real `tauri build`, which only happens in the release-only `publish` job, so normal CI/pre-commit never caught it.
- Ran `cargo update -p tauri-plugin-updater -p tauri-plugin-notification` to bring the crates to `2.11.0` / `2.4.0`, matching the npm side.

## Test plan
- [x] `cargo check` in `src-tauri/` compiles cleanly with the updated crate versions
- [ ] Re-run/re-publish the `12.12.1` release workflow (or the next release) to confirm `tauri build` succeeds on macOS and Windows

Fixes the failure seen in https://github.com/AdbAutoPlayer/AdbAutoPlayer/actions/runs/34300997597

🤖 Generated with [Claude Code](https://claude.com/claude-code)